### PR TITLE
build: remove unsupported yarn flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"docs": "typedoc",
 		"test": "jest",
 		"test:watch": "jest --watch",
-		"update": "yarn upgrade-interactive --latest",
+		"update": "yarn upgrade-interactive",
 		"build": "tsc -b src",
 		"clean": "tsc -b src --clean",
 		"watch": "tsc -b src -w",


### PR DESCRIPTION
Yarn v3 no longer has the `--latest` flag. [docs](https://yarnpkg.com/cli/upgrade-interactive)